### PR TITLE
Use sh

### DIFF
--- a/vmx
+++ b/vmx
@@ -104,7 +104,7 @@ update_vmx(){
   usage
 }
 
-if [ $EUID != 0 ]; then
+if [ `id -u` != 0 ]; then
   echo "You need root to run docker, try \`sudo ./vmx start 3000\`"
   exit 1
 fi


### PR DESCRIPTION
For some reason, I was getting errors with the $EUID part. Now sure why I had to make the change, but it seems to now work in boot2docker as well as in the cloud.
