### PR TITLE
Fix docker permission check flags

### DIFF
--- a/vmx
+++ b/vmx
@@ -89,7 +89,7 @@ boot2docker_extra() {
 }
 
 check_perm() {
-  docker run -rm busybox echo >/dev/null 2>&1
+  docker run --rm busybox echo >/dev/null 2>&1
   NON_ROOT_RUN_DOCKER_EXIT_CODE="$?"
   if [ $NON_ROOT_RUN_DOCKER_EXIT_CODE -eq 1 ] ; then
     echo "Permissions failed.."


### PR DESCRIPTION
On docker 1.7.0, the single-dash `-rm` option produces an error:
```
flag provided but not defined: -rm
```
causing [the permission check on line 99](https://github.com/VISIONAI/vmx-docker-manager/blob/8356ca550a03c869c7906d6cb01dc1cc52a2aadc/vmx#L99) to show:
```
Trying to run docker resulted in exit code: 2
```

After changing to the double-dash `--rm` the vmx script works fine. Tested these changes on docker 1.7.0 and 1.5.0.